### PR TITLE
fix: calculation prices after coupon in Cart/Checkout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor of some parts of views
 - Loading `homepage` vuex module only when needed (on 2 views)
 - Functional LoaderScoped.vue
+- Used helper for calculating product prices in Cart/Checkout
 
 ## [1.12.2] - UNRELEASED
 
@@ -44,4 +45,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 - Fixed closing sidebar after clicking on go to checkout button (#28)
-- Used helper for calculating product prices in Cart/Checkout

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor of some parts of views
 - Loading `homepage` vuex module only when needed (on 2 views)
 - Functional LoaderScoped.vue
-- Used helper for calculating product prices in Cart/Checkout
+- Using `getProductPrice` helper for calculating product prices in Cart/Checkout
 
 ## [1.12.2] - UNRELEASED
 

--- a/changelog.md
+++ b/changelog.md
@@ -44,3 +44,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed / Improved
 - Fixed closing sidebar after clicking on go to checkout button (#28)
+- Used helper for calculating product prices in Cart/Checkout

--- a/components/core/blocks/Microcart/Product.vue
+++ b/components/core/blocks/Microcart/Product.vue
@@ -62,29 +62,29 @@
         <div class="flex mr10 align-right start-xs between-sm prices">
           <div class="prices" v-if="!displayItemDiscounts || !isOnline">
             <span class="h4 serif cl-error price-special" v-if="product.special_price">
-              {{ product.price_incl_tax * product.qty | price(storeView) }}
+              {{ productPrice.special | price(storeView) }}
             </span>
             <span class="h6 serif price-original" v-if="product.special_price">
-              {{ product.original_price_incl_tax * product.qty | price(storeView) }}
+              {{ productPrice.original | price(storeView) }}
             </span>
             <span class="h4 serif price-regular" v-else data-testid="productPrice">
-              {{ (product.original_price_incl_tax ? product.original_price_incl_tax : product.price_incl_tax) * product.qty | price(storeView) }}
+              {{ productPrice.regular | price(storeView) }}
             </span>
           </div>
           <div class="prices" v-else-if="isOnline && product.totals">
             <span class="h4 serif cl-error price-special" v-if="product.totals.discount_amount">
-              {{ product.totals.row_total - product.totals.discount_amount + product.totals.tax_amount | price(storeView) }}
+              {{ productPrice.special | price(storeView) }}
             </span>
             <span class="h6 serif price-original" v-if="product.totals.discount_amount">
-              {{ product.totals.row_total_incl_tax | price(storeView) }}
+              {{ productPrice.original | price(storeView) }}
             </span>
             <span class="h4 serif price-regular" v-if="!product.totals.discount_amount">
-              {{ product.totals.row_total_incl_tax | price(storeView) }}
+              {{ productPrice.regular | price(storeView) }}
             </span>
           </div>
           <div class="prices" v-else>
             <span class="h4 serif price-regular">
-              {{ (product.regular_price || product.price_incl_tax) * product.qty | price(storeView) }}
+              {{ productPrice.regular | price(storeView) }}
             </span>
           </div>
         </div>
@@ -149,7 +149,7 @@ import RemoveButton from './RemoveButton'
 import EditButton from './EditButton'
 import { onlineHelper } from '@vue-storefront/core/helpers'
 import { ProductOption } from '@vue-storefront/core/modules/catalog/components/ProductOption'
-import { getThumbnailForProduct, getProductConfiguration } from '@vue-storefront/core/modules/cart/helpers'
+import { getThumbnailForProduct, getProductConfiguration, getProductPrice } from '@vue-storefront/core/modules/cart/helpers'
 import ButtonFull from 'theme/components/theme/ButtonFull'
 import EditMode from './EditMode'
 
@@ -215,6 +215,9 @@ export default {
     },
     productLink () {
       return formatProductLink(this.product, currentStoreView().storeCode)
+    },
+    productPrice () {
+      return getProductPrice(this.product)
     },
     editMode () {
       return this.getEditingProductId === this.product.id

--- a/components/core/blocks/Microcart/Product.vue
+++ b/components/core/blocks/Microcart/Product.vue
@@ -60,30 +60,14 @@
           />
         </div>
         <div class="flex mr10 align-right start-xs between-sm prices">
-          <div class="prices" v-if="!displayItemDiscounts || !isOnline">
-            <span class="h4 serif cl-error price-special" v-if="product.special_price">
+          <div class="prices">
+            <span class="h4 serif cl-error price-special" v-if="productPrice.special">
               {{ productPrice.special | price(storeView) }}
             </span>
-            <span class="h6 serif price-original" v-if="product.special_price">
+            <span class="h6 serif price-original" v-if="productPrice.original">
               {{ productPrice.original | price(storeView) }}
             </span>
-            <span class="h4 serif price-regular" v-else data-testid="productPrice">
-              {{ productPrice.regular | price(storeView) }}
-            </span>
-          </div>
-          <div class="prices" v-else-if="isOnline && product.totals">
-            <span class="h4 serif cl-error price-special" v-if="product.totals.discount_amount">
-              {{ productPrice.special | price(storeView) }}
-            </span>
-            <span class="h6 serif price-original" v-if="product.totals.discount_amount">
-              {{ productPrice.original | price(storeView) }}
-            </span>
-            <span class="h4 serif price-regular" v-if="!product.totals.discount_amount">
-              {{ productPrice.regular | price(storeView) }}
-            </span>
-          </div>
-          <div class="prices" v-else>
-            <span class="h4 serif price-regular">
+            <span class="h4 serif price-regular" v-if="productPrice.regular" data-testid="productPrice">
               {{ productPrice.regular | price(storeView) }}
             </span>
           </div>


### PR DESCRIPTION
### Related Issues
closes https://github.com/vuestorefront/vue-storefront/issues/4460

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Used new `getProductPrice` instead calculation in the vue component

Related PR: https://github.com/vuestorefront/vue-storefront/pull/5973

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-default/blob/master/CONTRIBUTING.md)